### PR TITLE
add instance discovery for cartesian products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+dist-newstyle

--- a/discover-instances.cabal
+++ b/discover-instances.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
 name:           discover-instances
-version:        0.1.0.0
+version:        0.1.1.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/discover-instances#readme>
 homepage:       https://github.com/parsonsmatt/discover-instances#readme
 bug-reports:    https://github.com/parsonsmatt/discover-instances/issues
@@ -33,6 +33,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.12 && <5
+    , containers
     , some-dict-of
     , template-haskell
     , th-compat
@@ -48,6 +49,7 @@ test-suite discover-instances-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.12 && <5
+    , containers
     , discover-instances
     , some-dict-of
     , template-haskell

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                discover-instances
-version:             0.1.0.0
+version:             0.1.1.0
 github:              "parsonsmatt/discover-instances"
 license:             BSD3
 author:              "Matt Parsons"
@@ -21,6 +21,7 @@ description:         Please see the README on GitHub at <https://github.com/pars
 
 dependencies:
 - base >= 4.12 && < 5
+- containers
 - template-haskell
 - some-dict-of
 - th-compat

--- a/src/DiscoverInstances.hs
+++ b/src/DiscoverInstances.hs
@@ -28,15 +28,23 @@ module DiscoverInstances
     (
     -- * The main interface
       discoverInstances
+    , discoverBothInstances
     -- * Using the results of 'discoverInstances'
     -- $using
     , withInstances
     , forInstances
+    , withBothInstances
+    , forBothInstances
     , module SomeDictOf
     -- * Re-exports
     , module Data.Proxy
     ) where
 
+import Data.Maybe (catMaybes)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Map.Merge.Strict as Merge
+import Data.Traversable (for)
 import Data.Proxy
 import Data.Typeable
 import Language.Haskell.TH hiding (cxt)
@@ -81,14 +89,10 @@ import SomeDictOf
 -- @since 0.1.0.0
 discoverInstances :: forall (c :: _ -> Constraint) . (Typeable c) => SpliceQ [SomeDict c]
 discoverInstances = liftSplice $ do
-    let
-        className =
-            show (typeRep (Proxy @c))
+    let className = show (typeRep (Proxy @c))
     instanceDecs <- reifyInstances (mkName className) [VarT (mkName "a")]
-
     dicts <- fmap listTE $ traverse decToDict instanceDecs
-
-    examineSplice [|| concat $$(liftSplice $ pure dicts) ||]
+    examineSplice [|| catMaybes $$(expToSplice dicts) ||]
 
 -- $using
 --
@@ -212,10 +216,101 @@ forInstances
 forInstances dicts f =
     traverse (\(SomeDictOf p) -> f p) dicts
 
+-- | This TemplateHaskell function accepts two types and splices in a list of
+-- 'SomeDict's that provide evidence that the type is an instance of **both**
+-- of the classes that you asked for.
+--
+-- That is to say: it takes the cartesian product of types in each set of
+-- instances and returns a list of 'SomeDict' pairs containing evidence of
+-- for that type's implementations of each of the two instances.
+--
+-- There are some limitations.
+--
+-- * The class can only accept a single parameter.
+-- * The instances returned do not have a context.
+--
+-- Example Use:
+--
+-- @
+-- eqShow :: [('SomeDict' 'Eq', 'SomeDict' 'Show')]
+-- eqShow = $$(discoverBothInstances)
+-- @
+--
+-- This function uses typed @TemplateHaskell@, which means you don't need to
+-- provide a type annotation directly. However, you can pass a type directly.
+--
+-- @
+-- ordShow :: ['SomeDict' 'Ord' 'Show']
+-- ordShow = $$(discoverBothInstances @Ord @Show)
+-- @
+--
+-- @since 0.1.1.0
+discoverBothInstances
+  :: forall (l :: _ -> Constraint) (r :: _ -> Constraint)
+   . (Typeable l, Typeable r)
+  => SpliceQ [(SomeDict l, SomeDict r)]
+discoverBothInstances = liftSplice $ do
+    instanceDecsL <- reifyInstanceDecMap @l
+    instanceDecsR <- reifyInstanceDecMap @r
+
+    let instanceDecs = Map.elems $ intersect instanceDecsL instanceDecsR
+    dicts <- for instanceDecs $ \(decL, decR) -> do
+      dictL <- decToDict decL
+      dictR <- decToDict decR
+      examineSplice [|| (,) <$> $$(expToSplice dictL) <*> $$(expToSplice dictR) ||]
+
+    examineSplice [|| catMaybes $$(expToSplice $ listTE dicts) ||]
+  where
+    reifyInstanceDecMap :: forall c. Typeable c => Q (Map Type InstanceDec)
+    reifyInstanceDecMap = do
+        let className = show (typeRep (Proxy @c))
+        instanceDecs <- reifyInstances (mkName className) [VarT (mkName "a")]
+        pure . Map.fromList $ map indexByType instanceDecs
+
+    indexByType :: InstanceDec -> (Type, InstanceDec)
+    indexByType i@(InstanceD _ _ typ _) = (typ, i)
+
+    intersect =
+        Merge.merge
+            Merge.dropMissing
+            Merge.dropMissing
+            (Merge.zipWithMatched (\_ l r -> (l, r)))
+
+-- | An alias for the pattern:
+--
+-- @
+-- flip map $$discoverBothInstances $ \\('SomeDictOf' l, 'SomeDictOf' r) -> f l r
+-- @
+--
+-- @since 0.1.1.0
+withBothInstances
+    :: Functor f
+    => f (SomeDict l, SomeDict r)
+    -> (forall a b. (l a, r b) => Proxy a -> Proxy b -> c)
+    -> f c
+withBothInstances dicts f =
+    fmap (\(SomeDictOf l, SomeDictOf r) -> f l r) dicts
+
+-- | An alias for the pattern:
+--
+-- @
+-- for $$discoverInstances $ \\('SomeDictOf' p) -> do
+--     f p
+-- @
+--
+-- @since 0.1.0.0
+forBothInstances
+    :: (Traversable t, Applicative f)
+    => t (SomeDict l, SomeDict r)
+    -> (forall a b. (l a, r b) => Proxy a -> Proxy b -> f c)
+    -> f (t c)
+forBothInstances dicts f =
+    traverse (\(SomeDictOf l, SomeDictOf r) -> f l r) dicts
+
 listTE :: [TExp a] -> TExp [a]
 listTE = TExp . ListE . map unType
 
-decToDict :: forall k (c :: k -> Constraint). InstanceDec -> Q (TExp [SomeDict c])
+decToDict :: forall k (c :: k -> Constraint). InstanceDec -> Q (TExp (Maybe (SomeDict c)))
 decToDict = \case
     InstanceD _moverlap cxt typ _decs ->
         case cxt of
@@ -233,16 +328,16 @@ decToDict = \case
                         x
                     proxy =
                         [| Proxy :: Proxy $(pure t) |]
-                unsafeTExpCoerce [| [ SomeDictOf $proxy ] |]
+                unsafeTExpCoerce [| Just (SomeDictOf $proxy) |]
             _ -> do
                 -- reportWarning $
                 --     "I haven't figured out how to put constrained instances on here, so I'm skipping the type: "
                 --     <> show typ
                 --     <> ", context: "
                 --     <> show cxt
-                examineSplice [|| [] ||]
+                examineSplice [|| Nothing ||]
 
     _ -> do
         reportWarning $
             "discoverInstances called on 'reifyInstances' somehow returned something that wasn't a type class instance."
-        examineSplice [|| [] ||]
+        examineSplice [|| Nothing ||]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,9 @@ show = $$(discoverInstances @Show)
 eq :: [SomeDict Eq]
 eq = $$(discoverInstances)
 
+eqShow :: [(SomeDict Eq, SomeDict Show)]
+eqShow = $$(discoverBothInstances)
+
 functor :: [SomeDict Functor]
 functor = $$discoverInstances
 


### PR DESCRIPTION
## description

I _thought_ I needed this for something, but despite that not being the case I had already written most of the code & figured it wouldn't be much more work to actually PR the thing.

## template

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
